### PR TITLE
Get inter_hybrid_to_pressure work with xarray apply_ufunc

### DIFF
--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -64,8 +64,10 @@ class Test_interp_hybrid_to_pressure:
         )
 
         uzon = u_int.mean(dim='lon')
+        # uzon = u_int.mean(dim='lon').isel(time=0)
 
         uzon_expected_t = ds_out.uzon.expand_dims("time")
+        # uzon_expected_t = ds_out.uzon
         nt.assert_array_almost_equal(uzon_expected_t, uzon, 5)
 
     def test_interp_hybrid_to_pressure_atmos_wrong_method(self) -> None:


### PR DESCRIPTION
This PR does the following:

`interp_hybrid_to_pressure`: Apart from the clean up in the code
* Calls `apply_ufunc` for output array to have `lev`, not `plev ` in dims. This creates conveniecne for later reordering, renaming etc. to make output look like the input re dimensions.
* See the re-added dims, renamings, re-orderings that start on Line-497
* The code block that involved `coords.update` after the `apply_ufunc` does not seem to do anything, so cleaned it.

`test_interpolation`:
* While kept as is within this PR, see the addition of commented out code in one of the test cases. The groundtruth does not have `time` dimension, and looks like we had the test case expand the expected array for that so far. I don't think that is needed, rather i-selevcting the `time=0` for the test output makes more sense to me.